### PR TITLE
Develop update to 3.2.2 nugets

### DIFF
--- a/NeonShooter/Content/Shaders/BloomCombine.fx
+++ b/NeonShooter/Content/Shaders/BloomCombine.fx
@@ -46,6 +46,10 @@ technique BloomCombine
 {
     pass Pass1
     {
-        PixelShader = compile ps_2_0 PixelShaderFunction();
+#if SM4		
+		PixelShader = compile ps_4_0_level_9_1 PixelShaderFunction();
+#else
+		PixelShader = compile ps_2_0 PixelShaderFunction();
+#endif
     }
 }

--- a/NeonShooter/Content/Shaders/BloomExtract.fx
+++ b/NeonShooter/Content/Shaders/BloomExtract.fx
@@ -20,6 +20,10 @@ technique BloomExtract
 {
     pass Pass1
     {
-        PixelShader = compile ps_2_0 PixelShaderFunction();
+#if SM4		
+		PixelShader = compile ps_4_0_level_9_1 PixelShaderFunction();
+#else
+		PixelShader = compile ps_2_0 PixelShaderFunction();
+#endif
     }
 }

--- a/NeonShooter/Content/Shaders/GaussianBlur.fx
+++ b/NeonShooter/Content/Shaders/GaussianBlur.fx
@@ -28,6 +28,10 @@ technique GaussianBlur
 {
     pass Pass1
     {
-        PixelShader = compile ps_2_0 PixelShaderFunction();
+#if SM4		
+		PixelShader = compile ps_4_0_level_9_1 PixelShaderFunction();
+#else
+		PixelShader = compile ps_2_0 PixelShaderFunction();
+#endif
     }
 }

--- a/NeonShooter/Platforms/WindowsGL/NeonShooter.csproj
+++ b/NeonShooter/Platforms/WindowsGL/NeonShooter.csproj
@@ -13,7 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>93fd0fd0</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>f4131cf8</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -258,9 +258,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\net40\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\net40\MonoGame.Binaries.targets'))" />
   </Target>
-  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets')" />
+  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\net40\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\net40\MonoGame.Binaries.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/NeonShooter/Platforms/WindowsGL/packages.config
+++ b/NeonShooter/Platforms/WindowsGL/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Binaries" version="3.2.0" targetFramework="net40" />
+  <package id="MonoGame.Binaries" version="3.2.2-alpha" targetFramework="net40" />
 </packages>

--- a/Platformer2D/Content/Platformer2D.contentproj
+++ b/Platformer2D/Content/Platformer2D.contentproj
@@ -46,7 +46,7 @@
     <Reference Include="Microsoft.Xna.Framework.Content.Pipeline.AudioImporters" />
     <Reference Include="Microsoft.Xna.Framework.Content.Pipeline.VideoImporters" />
     <Reference Include="MonoGameContentProcessors">
-      <HintPath>..\..\packages\MonoGame.ContentProcessors.3.1.0-alpha\lib\net\MonoGameContentProcessors.dll</HintPath>
+      <HintPath>..\..\packages\MonoGame.ContentProcessors.3.2.1\lib\MonoGameContentProcessors.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Platformer2D/Game.cs
+++ b/Platformer2D/Game.cs
@@ -143,10 +143,11 @@ namespace Platformer2D
             gamePadState = virtualGamePad.GetState(touchState, GamePad.GetState(PlayerIndex.One));
             accelerometerState = Accelerometer.GetState();
 
+#if !NETFX_CORE
             // Exit the game when back is pressed.
             if (gamePadState.Buttons.Back == ButtonState.Pressed)
                 Exit();
-
+#endif
             bool continuePressed =
                 keyboardState.IsKeyDown(Keys.Space) ||
                 gamePadState.IsButtonDown(Buttons.A) ||

--- a/Platformer2D/Platforms/Android/Platformer2D.csproj
+++ b/Platformer2D/Platforms/Android/Platformer2D.csproj
@@ -24,7 +24,7 @@
     <JavaOptions />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>e8062b78</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>2d589de7</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -337,9 +337,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\MonoAndroid\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.0\build\MonoAndroid\MonoGame.Binaries.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\MonoAndroid\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\MonoAndroid\MonoGame.Binaries.targets'))" />
   </Target>
-  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.0\build\MonoAndroid\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\MonoAndroid\MonoGame.Binaries.targets')" />
+  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\MonoAndroid\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\MonoAndroid\MonoGame.Binaries.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
      Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Platformer2D/Platforms/Android/packages.config
+++ b/Platformer2D/Platforms/Android/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Binaries" version="3.2.0" targetFramework="MonoAndroid31" />
+  <package id="MonoGame.Binaries" version="3.2.2-alpha" targetFramework="MonoAndroid31" />
 </packages>

--- a/Platformer2D/Platforms/OSX/Platformer2D.csproj
+++ b/Platformer2D/Platforms/OSX/Platformer2D.csproj
@@ -316,7 +316,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\MonoMac\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.0\build\MonoMac\MonoGame.Binaries.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\MonoMac\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\MonoMac\MonoGame.Binaries.targets'))" />
   </Target>
-  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.0\build\MonoMac\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\MonoMac\MonoGame.Binaries.targets')" />
+  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\MonoMac\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\MonoMac\MonoGame.Binaries.targets')" />
 </Project>

--- a/Platformer2D/Platforms/OSX/packages.config
+++ b/Platformer2D/Platforms/OSX/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Binaries" version="3.2.0" targetFramework="MonoTouch10" />
+  <package id="MonoGame.Binaries" version="3.2.2-alpha" targetFramework="MonoMac" />
 </packages>

--- a/Platformer2D/Platforms/Windows8/Platformer2D.csproj
+++ b/Platformer2D/Platforms/Windows8/Platformer2D.csproj
@@ -15,7 +15,7 @@
     <PackageCertificateKeyFile>Platformer2D_TemporaryKey.pfx</PackageCertificateKeyFile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>692aedac</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>c1f843da</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -372,12 +372,12 @@
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.0\build\netcore\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\netcore\MonoGame.Binaries.targets')" />
+  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\netcore\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\netcore\MonoGame.Binaries.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\netcore\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.0\build\netcore\MonoGame.Binaries.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\netcore\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\netcore\MonoGame.Binaries.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Platformer2D/Platforms/Windows8/packages.config
+++ b/Platformer2D/Platforms/Windows8/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Binaries" version="3.2.0" targetFramework="win" />
+  <package id="MonoGame.Binaries" version="3.2.2-alpha" targetFramework="win" />
 </packages>

--- a/Platformer2D/Platforms/WindowsGL/Platformer2D.csproj
+++ b/Platformer2D/Platforms/WindowsGL/Platformer2D.csproj
@@ -13,7 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>da8b6c4c</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>8d35c1d1</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -302,12 +302,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets')" />
+  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\net40\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\net40\MonoGame.Binaries.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\net40\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\net40\MonoGame.Binaries.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Platformer2D/Platforms/WindowsGL/packages.config
+++ b/Platformer2D/Platforms/WindowsGL/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Binaries" version="3.2.0" targetFramework="net40" />
+  <package id="MonoGame.Binaries" version="3.2.2-alpha" targetFramework="net40" />
 </packages>

--- a/Platformer2D/Platforms/WindowsPhone/Platformer2D.csproj
+++ b/Platformer2D/Platforms/WindowsPhone/Platformer2D.csproj
@@ -27,7 +27,7 @@
     <ThrowErrorsInValidation>true</ThrowErrorsInValidation>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>6366bde4</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>f9812800</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -388,11 +388,11 @@
   -->
   <ProjectExtensions />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.0\build\wp8\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\wp8\MonoGame.Binaries.targets')" />
+  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\wp8\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\wp8\MonoGame.Binaries.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\wp8\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.0\build\wp8\MonoGame.Binaries.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\wp8\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\wp8\MonoGame.Binaries.targets'))" />
   </Target>
 </Project>

--- a/Platformer2D/Platforms/WindowsPhone/packages.config
+++ b/Platformer2D/Platforms/WindowsPhone/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Binaries" version="3.2.0" targetFramework="wp80" />
+  <package id="MonoGame.Binaries" version="3.2.2-alpha" targetFramework="wp80" />
 </packages>

--- a/Platformer2D/Platforms/iOS/Platformer2D.csproj
+++ b/Platformer2D/Platforms/iOS/Platformer2D.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Platformer2D</AssemblyName>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>197690a1</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>b6a9f92e</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>True</DebugSymbols>
@@ -349,7 +349,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\MonoTouch\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.0\build\MonoTouch\MonoGame.Binaries.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\MonoTouch\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\MonoTouch\MonoGame.Binaries.targets'))" />
   </Target>
-  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.0\build\MonoTouch\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\MonoTouch\MonoGame.Binaries.targets')" />
+  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\MonoTouch\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\MonoTouch\MonoGame.Binaries.targets')" />
 </Project>

--- a/Platformer2D/Platforms/iOS/packages.config
+++ b/Platformer2D/Platforms/iOS/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Binaries" version="3.2.0" targetFramework="MonoTouch10" />
+  <package id="MonoGame.Binaries" version="3.2.2-alpha" targetFramework="MonoTouch10" />
 </packages>

--- a/Samples-Content.sln
+++ b/Samples-Content.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2010
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30501.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContentBuilder", "ContentBuilder\ContentBuilder.csproj", "{7CF308F8-F4F1-48D5-A1A5-533F4A4BBE5D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Platformer2D", "Platformer2D\Content\Platformer2D.contentproj", "{935F72E1-0493-499D-ABDB-A65808B8D304}"
@@ -55,7 +57,6 @@ Global
 		{C901B318-3A34-4BA7-972F-47903D620E86}.PSM|Any CPU.ActiveCfg = PSM|Any CPU
 		{C901B318-3A34-4BA7-972F-47903D620E86}.Windows|Any CPU.ActiveCfg = Windows|Any CPU
 		{C901B318-3A34-4BA7-972F-47903D620E86}.Windows8|Any CPU.ActiveCfg = Windows8|Any CPU
-	EndGlobalSection
 		{1E2A443A-EB3F-44B2-915A-471C50AF180A}.Android|Any CPU.ActiveCfg = Android|Any CPU
 		{1E2A443A-EB3F-44B2-915A-471C50AF180A}.iOS|Any CPU.ActiveCfg = iOS|Any CPU
 		{1E2A443A-EB3F-44B2-915A-471C50AF180A}.Linux|Any CPU.ActiveCfg = Linux|Any CPU

--- a/Samples-WindowsGL.sln
+++ b/Samples-WindowsGL.sln
@@ -1,11 +1,12 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2010
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30501.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Platformer2D", "Platformer2D\Platforms\WindowsGL\Platformer2D.csproj", "{CAF988BD-5440-405D-95D5-BCAB25FC5240}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpaceWar", "SpaceWar\Platforms\WindowsGL\SpaceWar.csproj", "{3078F3FC-5D65-42CC-96AC-0C28FE1D2D8B}"
 EndProject
-Global
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NeonShooter", "NeonShooter\Platforms\WindowsGL\NeonShooter.csproj", "{8D355B2D-AA42-4315-AEC2-2E3BCA6B2605}"
 EndProject
 Global
@@ -183,7 +184,6 @@ Global
 		{3078F3FC-5D65-42CC-96AC-0C28FE1D2D8B}.Windows8|x64.ActiveCfg = Release|x86
 		{3078F3FC-5D65-42CC-96AC-0C28FE1D2D8B}.Windows8|x86.ActiveCfg = Release|x86
 		{3078F3FC-5D65-42CC-96AC-0C28FE1D2D8B}.Windows8|x86.Build.0 = Release|x86
-	EndGlobalSection
 		{8D355B2D-AA42-4315-AEC2-2E3BCA6B2605}.Android|Any CPU.ActiveCfg = Release|x86
 		{8D355B2D-AA42-4315-AEC2-2E3BCA6B2605}.Android|ARM.ActiveCfg = Release|x86
 		{8D355B2D-AA42-4315-AEC2-2E3BCA6B2605}.Android|Mixed Platforms.ActiveCfg = Release|x86

--- a/SpaceWar/Game.cs
+++ b/SpaceWar/Game.cs
@@ -221,10 +221,12 @@ namespace Spacewar
                     paused = !paused;
                 }
 
+#if !NETFX_CORE
                 if (gameState == GameState.LogoSplash)
                 {
                     this.Exit();
                 }
+#endif
             }
 
             //Reload settings file?

--- a/SpaceWar/Platforms/Windows8/SpaceWar.csproj
+++ b/SpaceWar/Platforms/Windows8/SpaceWar.csproj
@@ -15,7 +15,7 @@
     <PackageCertificateKeyFile>SpaceWar_TemporaryKey.pfx</PackageCertificateKeyFile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>4043ec9b</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>e4e47c9d</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -724,9 +724,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\netcore\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.0\build\netcore\MonoGame.Binaries.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\netcore\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\netcore\MonoGame.Binaries.targets'))" />
   </Target>
-  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.0\build\netcore\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\netcore\MonoGame.Binaries.targets')" />
+  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\netcore\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\netcore\MonoGame.Binaries.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/SpaceWar/Platforms/Windows8/packages.config
+++ b/SpaceWar/Platforms/Windows8/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Binaries" version="3.2.0" targetFramework="win" />
+  <package id="MonoGame.Binaries" version="3.2.2-alpha" targetFramework="win" />
 </packages>

--- a/SpaceWar/Platforms/WindowsGL/SpaceWar.csproj
+++ b/SpaceWar/Platforms/WindowsGL/SpaceWar.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7d740c9b</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -649,12 +650,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets')" />
+  <Import Project="..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\net40\MonoGame.Binaries.targets" Condition="Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\net40\MonoGame.Binaries.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.0\build\net40\MonoGame.Binaries.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\net40\MonoGame.Binaries.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\MonoGame.Binaries.3.2.2-alpha\build\net40\MonoGame.Binaries.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/SpaceWar/Platforms/WindowsGL/packages.config
+++ b/SpaceWar/Platforms/WindowsGL/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame.Binaries" version="3.2.0" targetFramework="net40" />
+  <package id="MonoGame.Binaries" version="3.2.2-alpha" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Updates and patches to upgrade the develop brance samples to the latest dev release NuGet's
- Updated shaders in NeonSample to allow building content for Win 8
- added #if to ignore Exit on win8 platforms because it was deprecated
- Updated NuGet packages for supported platforms, remaining platforms still at 3.2 full
