### PR TITLE
Updated fonts in both Platformer and NeonShooter to use Arial

### DIFF
--- a/NeonShooter/Content/Font.spritefont
+++ b/NeonShooter/Content/Font.spritefont
@@ -11,7 +11,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>Moire</FontName>
+    <FontName>Arial</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change

--- a/Platformer2D/Content/Fonts/Hud.spritefont
+++ b/Platformer2D/Content/Fonts/Hud.spritefont
@@ -11,7 +11,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>Pericles</FontName>
+    <FontName>Arial</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change


### PR DESCRIPTION
Updated fonts in both Platformer and NeonShooter to use Arial as this is a more common font on clean machines without XNA
