### PR TITLE
Add link to original NeonShooter tutorial series

### DIFF
--- a/NeonShooter/README.md
+++ b/NeonShooter/README.md
@@ -1,0 +1,3 @@
+# NeonShooter Sample
+
+Find the tutorial series for this sample here: [Cross-Platform Vector Shooter: XNA - Michael Hoffman](https://gamedevelopment.tutsplus.com/series/cross-platform-vector-shooter-xna--gamedev-10559)


### PR DESCRIPTION
There is a tutorial series for this sample code. It's for XNA, but I'm sure it's still quite useful. This also has the side effect of fixing the broken link on the main README.md.