### PR TITLE
Fix some issues with loading Xml content

### DIFF
--- a/ShipGame/.vscode/launch.json
+++ b/ShipGame/.vscode/launch.json
@@ -6,9 +6,9 @@
     "configurations": [
         {
             "name": "Android Debug",
-            "type": "dotnet",
+            "type": "maui",
             "request": "launch",
-            "projectPath": "${workspaceFolder}/ShipGame.Android/ShipGame.Android.csproj"
+            "preLaunchTask": "maui: Build",
         },
         {
             "name": "DesktopGL Debug",
@@ -18,9 +18,9 @@
         },
         {
             "name": "iOS Debug",
-            "type": "dotnet",
+            "type": "maui",
             "request": "launch",
-            "projectPath": "${workspaceFolder}/ShipGame.iOS/ShipGame.iOS.csproj"
+            "preLaunchTask": "maui: Build",
         },
         {
             "name": "WindowsDX Debug",

--- a/ShipGame/ShipGame.Core/Game/EntityList.cs
+++ b/ShipGame/ShipGame.Core/Game/EntityList.cs
@@ -8,7 +8,8 @@
 #endregion
 
 #region Using Statements
-using Microsoft.Xna.Framework;using System;
+using Microsoft.Xna.Framework;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml.Serialization;
@@ -122,7 +123,7 @@ namespace ShipGame
             Stream stream;
             try
             {
-                stream = File.OpenRead(filename);
+                stream = TitleContainer.OpenStream(filename);
             }
             catch (FileNotFoundException e)
             {

--- a/ShipGame/ShipGame.Core/Game/GameManager.cs
+++ b/ShipGame/ShipGame.Core/Game/GameManager.cs
@@ -14,6 +14,7 @@ using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using System;
+using System.IO;
 #endregion
 
 namespace ShipGame
@@ -245,8 +246,8 @@ namespace ShipGame
             collisionModel = null;
 
             // load spawns and lights
-            levelSpawns = EntityList.Load("content/levels/" + level + "_spawns.xml");
-            levelLights = LightList.Load("content/levels/" + level + "_lights.xml");
+            levelSpawns = EntityList.Load(Path.Combine(content.RootDirectory, "levels", level + "_spawns.xml"));
+            levelLights = LightList.Load(Path.Combine(content.RootDirectory, "levels", level + "_lights.xml"));
 
             // load particle textures
             if (particleTextures == null)

--- a/ShipGame/ShipGame.Core/Game/Graphics/LightList.cs
+++ b/ShipGame/ShipGame.Core/Game/Graphics/LightList.cs
@@ -9,7 +9,8 @@
 
 #region Using Statements
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;using System;
+using Microsoft.Xna.Framework.Graphics;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml.Serialization;
@@ -94,7 +95,7 @@ namespace ShipGame
             Stream stream;
             try
             {
-                stream = File.OpenRead(filename);
+                stream = TitleContainer.OpenStream(filename);
             }
             catch (FileNotFoundException e)
             {

--- a/ShipGame/ShipGame.Core/Game/Screens/ScreenPlayer.cs
+++ b/ShipGame/ShipGame.Core/Game/Screens/ScreenPlayer.cs
@@ -13,6 +13,7 @@ using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using System;
+using System.IO;
 #endregion
 
 namespace ShipGame
@@ -80,7 +81,7 @@ namespace ShipGame
                 rotation[0] = Matrix.Identity;
                 rotation[1] = Matrix.Identity;
 
-                lights = LightList.Load("content/screens/player_lights.xml");
+                lights = LightList.Load( Path.Combine(content.RootDirectory, "screens", "player_lights.xml"));
 
                 for (int i = 0; i < NumberShips; i++)
                 {


### PR DESCRIPTION
Fix some issues where the code was using `File.OpenRead` to read xml files. 
This will not work on platforms like Android since the files will be in an Apk not on the file system. 
Replace this with `TitleContainer.OpenStream` which does the right thing on each platform. 
Also fix up the hardcoded `content` file paths  which will break on case sensitive operating systems like Mac, iOS, Linux and Android. 

Add some change to launch.json to use the maui vscode extension.