### PR TITLE
Normalize vector before reflecting for bat bounce.

### DIFF
--- a/Tutorials/learn-monogame-2d/src/12-Collision-Detection/DungeonSlime/Game1.cs
+++ b/Tutorials/learn-monogame-2d/src/12-Collision-Detection/DungeonSlime/Game1.cs
@@ -151,6 +151,7 @@ public class Game1 : Core
         // normal.
         if (normal != Vector2.Zero)
         {
+            normal.Normalize();
             _batVelocity = Vector2.Reflect(_batVelocity, normal);
         }
 

--- a/Tutorials/learn-monogame-2d/src/13-Tilemap/DungeonSlime/Game1.cs
+++ b/Tutorials/learn-monogame-2d/src/13-Tilemap/DungeonSlime/Game1.cs
@@ -166,6 +166,7 @@ public class Game1 : Core
         // normal.
         if (normal != Vector2.Zero)
         {
+            normal.Normalize();
             _batVelocity = Vector2.Reflect(_batVelocity, normal);
         }
 

--- a/Tutorials/learn-monogame-2d/src/14-SoundEffects-And-Music/DungeonSlime/Game1.cs
+++ b/Tutorials/learn-monogame-2d/src/14-SoundEffects-And-Music/DungeonSlime/Game1.cs
@@ -195,6 +195,7 @@ public class Game1 : Core
         // normal.
         if (normal != Vector2.Zero)
         {
+            normal.Normalize();
             _batVelocity = Vector2.Reflect(_batVelocity, normal);
 
             // Play the bounce sound effect

--- a/Tutorials/learn-monogame-2d/src/15-Audio-Controller/DungeonSlime/Game1.cs
+++ b/Tutorials/learn-monogame-2d/src/15-Audio-Controller/DungeonSlime/Game1.cs
@@ -189,6 +189,7 @@ public class Game1 : Core
         // normal.
         if (normal != Vector2.Zero)
         {
+            normal.Normalize();
             _batVelocity = Vector2.Reflect(_batVelocity, normal);
 
             // Play the bounce sound effect

--- a/Tutorials/learn-monogame-2d/src/16-Working-With-SpriteFonts/DungeonSlime/Game1.cs
+++ b/Tutorials/learn-monogame-2d/src/16-Working-With-SpriteFonts/DungeonSlime/Game1.cs
@@ -213,6 +213,7 @@ public class Game1 : Core
         // normal.
         if (normal != Vector2.Zero)
         {
+            normal.Normalize();
             _batVelocity = Vector2.Reflect(_batVelocity, normal);
 
             // Play the bounce sound effect

--- a/Tutorials/learn-monogame-2d/src/17-Scenes/DungeonSlime/Scenes/GameScene.cs
+++ b/Tutorials/learn-monogame-2d/src/17-Scenes/DungeonSlime/Scenes/GameScene.cs
@@ -203,6 +203,7 @@ public class GameScene : Scene
         // normal.
         if (normal != Vector2.Zero)
         {
+            normal.Normalize();
             _batVelocity = Vector2.Reflect(_batVelocity, normal);
 
             // Play the bounce sound effect

--- a/Tutorials/learn-monogame-2d/src/18-Texture-Wrapping/DungeonSlime/Scenes/GameScene.cs
+++ b/Tutorials/learn-monogame-2d/src/18-Texture-Wrapping/DungeonSlime/Scenes/GameScene.cs
@@ -203,6 +203,7 @@ public class GameScene : Scene
         // normal.
         if (normal != Vector2.Zero)
         {
+            normal.Normalize();
             _batVelocity = Vector2.Reflect(_batVelocity, normal);
 
             // Play the bounce sound effect

--- a/Tutorials/learn-monogame-2d/src/19-User-Interface-Fundamentals/DungeonSlime/Scenes/GameScene.cs
+++ b/Tutorials/learn-monogame-2d/src/19-User-Interface-Fundamentals/DungeonSlime/Scenes/GameScene.cs
@@ -203,6 +203,7 @@ public class GameScene : Scene
         // normal.
         if (normal != Vector2.Zero)
         {
+            normal.Normalize();
             _batVelocity = Vector2.Reflect(_batVelocity, normal);
 
             // Play the bounce sound effect

--- a/Tutorials/learn-monogame-2d/src/20-Implementing-UI-With-Gum/DungeonSlime/Scenes/GameScene.cs
+++ b/Tutorials/learn-monogame-2d/src/20-Implementing-UI-With-Gum/DungeonSlime/Scenes/GameScene.cs
@@ -300,6 +300,7 @@ public class GameScene : Scene
         // normal.
         if (normal != Vector2.Zero)
         {
+            normal.Normalize();
             _batVelocity = Vector2.Reflect(_batVelocity, normal);
 
             // Play the bounce sound effect

--- a/Tutorials/learn-monogame-2d/src/21-Customizing-Gum-UI/DungeonSlime/Scenes/GameScene.cs
+++ b/Tutorials/learn-monogame-2d/src/21-Customizing-Gum-UI/DungeonSlime/Scenes/GameScene.cs
@@ -314,6 +314,7 @@ public class GameScene : Scene
         // normal.
         if (normal != Vector2.Zero)
         {
+            normal.Normalize();
             _batVelocity = Vector2.Reflect(_batVelocity, normal);
 
             // Play the bounce sound effect

--- a/Tutorials/learn-monogame-2d/src/22-Snake-Game-Mechanics/DungeonSlime/GameObjects/Bat.cs
+++ b/Tutorials/learn-monogame-2d/src/22-Snake-Game-Mechanics/DungeonSlime/GameObjects/Bat.cs
@@ -80,6 +80,9 @@ public class Bat
         // Apply the new position
         Position = newPosition;
 
+        // Normalize before reflecting
+        normal.Normalize();
+
         // Apply reflection based on the normal.
         _velocity = Vector2.Reflect(_velocity, normal);
 

--- a/Tutorials/learn-monogame-2d/src/23-Completing-The-Game/DungeonSlime/GameObjects/Bat.cs
+++ b/Tutorials/learn-monogame-2d/src/23-Completing-The-Game/DungeonSlime/GameObjects/Bat.cs
@@ -80,6 +80,9 @@ public class Bat
         // Apply the new position
         Position = newPosition;
 
+        // Normalize before reflecting
+        normal.Normalize();        
+
         // Apply reflection based on the normal.
         _velocity = Vector2.Reflect(_velocity, normal);
 

--- a/Tutorials/learn-monogame-2d/src/24-Shaders/DungeonSlime/GameObjects/Bat.cs
+++ b/Tutorials/learn-monogame-2d/src/24-Shaders/DungeonSlime/GameObjects/Bat.cs
@@ -80,6 +80,9 @@ public class Bat
         // Apply the new position
         Position = newPosition;
 
+        // Normalize before reflecting
+        normal.Normalize();        
+
         // Apply reflection based on the normal.
         _velocity = Vector2.Reflect(_velocity, normal);
 

--- a/Tutorials/learn-monogame-2d/src/25-Packaging-Game/DungeonSlime/GameObjects/Bat.cs
+++ b/Tutorials/learn-monogame-2d/src/25-Packaging-Game/DungeonSlime/GameObjects/Bat.cs
@@ -80,6 +80,9 @@ public class Bat
         // Apply the new position
         Position = newPosition;
 
+        // Normalize before reflecting
+        normal.Normalize();        
+
         // Apply reflection based on the normal.
         _velocity = Vector2.Reflect(_velocity, normal);
 

--- a/Tutorials/learn-monogame-2d/src/26-Publish-To-Itch/DungeonSlime/GameObjects/Bat.cs
+++ b/Tutorials/learn-monogame-2d/src/26-Publish-To-Itch/DungeonSlime/GameObjects/Bat.cs
@@ -80,6 +80,9 @@ public class Bat
         // Apply the new position
         Position = newPosition;
 
+        // Normalize before reflecting
+        normal.Normalize();        
+
         // Apply reflection based on the normal.
         _velocity = Vector2.Reflect(_velocity, normal);
 

--- a/Tutorials/learn-monogame-2d/src/27-Conclusion/DungeonSlime/GameObjects/Bat.cs
+++ b/Tutorials/learn-monogame-2d/src/27-Conclusion/DungeonSlime/GameObjects/Bat.cs
@@ -80,6 +80,9 @@ public class Bat
         // Apply the new position
         Position = newPosition;
 
+        // Normalize before reflecting
+        normal.Normalize();        
+
         // Apply reflection based on the normal.
         _velocity = Vector2.Reflect(_velocity, normal);
 


### PR DESCRIPTION
## Summary

Normalizes the vector before calculating the reflection for the bat bounce in the 2D tutorial

## References
- Closes: #96 
- https://github.com/MonoGame/docs.monogame.github.io/issues/172