### PR TITLE
Remove unused TextureRegion code in `Tilemap.FromFile`

### DIFF
--- a/Tutorials/learn-monogame-2d/src/13-Tilemap/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/13-Tilemap/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/14-SoundEffects-And-Music/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/14-SoundEffects-And-Music/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/15-Audio-Controller/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/15-Audio-Controller/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/16-Working-With-SpriteFonts/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/16-Working-With-SpriteFonts/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/17-Scenes/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/17-Scenes/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/18-Texture-Wrapping/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/18-Texture-Wrapping/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/19-User-Interface-Fundamentals/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/19-User-Interface-Fundamentals/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/20-Implementing-UI-With-Gum/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/20-Implementing-UI-With-Gum/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/21-Customizing-Gum-UI/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/21-Customizing-Gum-UI/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/22-Snake-Game-Mechanics/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/22-Snake-Game-Mechanics/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/23-Completing-The-Game/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/23-Completing-The-Game/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/24-Shaders/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/24-Shaders/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/25-Packaging-Game/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/25-Packaging-Game/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/26-Publish-To-Itch/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/26-Publish-To-Itch/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }

--- a/Tutorials/learn-monogame-2d/src/27-Conclusion/MonoGameLibrary/Graphics/Tilemap.cs
+++ b/Tutorials/learn-monogame-2d/src/27-Conclusion/MonoGameLibrary/Graphics/Tilemap.cs
@@ -216,9 +216,6 @@ public class Tilemap
                         // Get the tileset index for this location
                         int tilesetIndex = int.Parse(columns[column]);
 
-                        // Get the texture region of that tile from the tileset
-                        TextureRegion region = tileset.GetTile(tilesetIndex);
-
                         // Add that region to the tilemap at the row and column location
                         tilemap.SetTile(column, row, tilesetIndex);
                     }


### PR DESCRIPTION
Removes the unused TextureRegion creation code from `Tilemap.FromFile`

This is related to the PR in the tutorial documentation at https://github.com/MonoGame/docs.monogame.github.io/pull/193