### PR TITLE
Add `IsDisposed=true` to `Scene` disposal

### DIFF
--- a/Tutorials/learn-monogame-2d/src/17-Scenes/MonoGameLibrary/Scenes/Scene.cs
+++ b/Tutorials/learn-monogame-2d/src/17-Scenes/MonoGameLibrary/Scenes/Scene.cs
@@ -100,5 +100,7 @@ public abstract class Scene : IDisposable
             UnloadContent();
             Content.Dispose();
         }
+
+        IsDisposed = true;
     }
 }

--- a/Tutorials/learn-monogame-2d/src/18-Texture-Wrapping/MonoGameLibrary/Scenes/Scene.cs
+++ b/Tutorials/learn-monogame-2d/src/18-Texture-Wrapping/MonoGameLibrary/Scenes/Scene.cs
@@ -100,5 +100,7 @@ public abstract class Scene : IDisposable
             UnloadContent();
             Content.Dispose();
         }
+
+        IsDisposed = true;
     }
 }

--- a/Tutorials/learn-monogame-2d/src/19-User-Interface-Fundamentals/MonoGameLibrary/Scenes/Scene.cs
+++ b/Tutorials/learn-monogame-2d/src/19-User-Interface-Fundamentals/MonoGameLibrary/Scenes/Scene.cs
@@ -100,5 +100,7 @@ public abstract class Scene : IDisposable
             UnloadContent();
             Content.Dispose();
         }
+
+        IsDisposed = true;
     }
 }

--- a/Tutorials/learn-monogame-2d/src/20-Implementing-UI-With-Gum/MonoGameLibrary/Scenes/Scene.cs
+++ b/Tutorials/learn-monogame-2d/src/20-Implementing-UI-With-Gum/MonoGameLibrary/Scenes/Scene.cs
@@ -100,5 +100,7 @@ public abstract class Scene : IDisposable
             UnloadContent();
             Content.Dispose();
         }
+
+        IsDisposed = true;
     }
 }

--- a/Tutorials/learn-monogame-2d/src/21-Customizing-Gum-UI/MonoGameLibrary/Scenes/Scene.cs
+++ b/Tutorials/learn-monogame-2d/src/21-Customizing-Gum-UI/MonoGameLibrary/Scenes/Scene.cs
@@ -100,5 +100,7 @@ public abstract class Scene : IDisposable
             UnloadContent();
             Content.Dispose();
         }
+
+        IsDisposed = true;
     }
 }

--- a/Tutorials/learn-monogame-2d/src/22-Snake-Game-Mechanics/MonoGameLibrary/Scenes/Scene.cs
+++ b/Tutorials/learn-monogame-2d/src/22-Snake-Game-Mechanics/MonoGameLibrary/Scenes/Scene.cs
@@ -100,5 +100,7 @@ public abstract class Scene : IDisposable
             UnloadContent();
             Content.Dispose();
         }
+
+        IsDisposed = true;
     }
 }

--- a/Tutorials/learn-monogame-2d/src/23-Completing-The-Game/MonoGameLibrary/Scenes/Scene.cs
+++ b/Tutorials/learn-monogame-2d/src/23-Completing-The-Game/MonoGameLibrary/Scenes/Scene.cs
@@ -100,5 +100,7 @@ public abstract class Scene : IDisposable
             UnloadContent();
             Content.Dispose();
         }
+
+        IsDisposed = true;
     }
 }

--- a/Tutorials/learn-monogame-2d/src/24-Shaders/MonoGameLibrary/Scenes/Scene.cs
+++ b/Tutorials/learn-monogame-2d/src/24-Shaders/MonoGameLibrary/Scenes/Scene.cs
@@ -100,5 +100,7 @@ public abstract class Scene : IDisposable
             UnloadContent();
             Content.Dispose();
         }
+
+        IsDisposed = true;
     }
 }

--- a/Tutorials/learn-monogame-2d/src/25-Packaging-Game/MonoGameLibrary/Scenes/Scene.cs
+++ b/Tutorials/learn-monogame-2d/src/25-Packaging-Game/MonoGameLibrary/Scenes/Scene.cs
@@ -100,5 +100,7 @@ public abstract class Scene : IDisposable
             UnloadContent();
             Content.Dispose();
         }
+
+        IsDisposed = true;
     }
 }

--- a/Tutorials/learn-monogame-2d/src/26-Publish-To-Itch/MonoGameLibrary/Scenes/Scene.cs
+++ b/Tutorials/learn-monogame-2d/src/26-Publish-To-Itch/MonoGameLibrary/Scenes/Scene.cs
@@ -100,5 +100,7 @@ public abstract class Scene : IDisposable
             UnloadContent();
             Content.Dispose();
         }
+
+        IsDisposed = true;
     }
 }

--- a/Tutorials/learn-monogame-2d/src/27-Conclusion/MonoGameLibrary/Scenes/Scene.cs
+++ b/Tutorials/learn-monogame-2d/src/27-Conclusion/MonoGameLibrary/Scenes/Scene.cs
@@ -100,5 +100,7 @@ public abstract class Scene : IDisposable
             UnloadContent();
             Content.Dispose();
         }
+
+        IsDisposed = true;
     }
 }


### PR DESCRIPTION
This adds `IsDisposed = true` to each of the `Scene.cs` classes in the 2D tutorial.  This was originally pointed out as missing by @jordanlhunt in https://github.com/MonoGame/docs.monogame.github.io/pull/202