### PR TITLE
Bumps Gum to the latest version as of this commit to address focus ta…

### DIFF
--- a/Tutorials/learn-monogame-2d/src/20-Implementing-UI-With-Gum/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/20-Implementing-UI-With-Gum/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.8.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/20-Implementing-UI-With-Gum/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/20-Implementing-UI-With-Gum/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2025.12.9.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/21-Customizing-Gum-UI/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/21-Customizing-Gum-UI/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.8.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/21-Customizing-Gum-UI/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/21-Customizing-Gum-UI/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2025.12.9.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/22-Snake-Game-Mechanics/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/22-Snake-Game-Mechanics/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.8.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/22-Snake-Game-Mechanics/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/22-Snake-Game-Mechanics/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2025.12.9.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/23-Completing-The-Game/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/23-Completing-The-Game/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.8.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/23-Completing-The-Game/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/23-Completing-The-Game/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2025.12.9.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/24-Shaders/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/24-Shaders/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.8.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/24-Shaders/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/24-Shaders/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2025.12.9.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/25-Packaging-Game/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/25-Packaging-Game/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.8.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/25-Packaging-Game/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/25-Packaging-Game/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2025.12.9.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/26-Publish-To-Itch/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/26-Publish-To-Itch/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.8.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/26-Publish-To-Itch/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/26-Publish-To-Itch/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2025.12.9.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/27-Conclusion/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/27-Conclusion/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.8.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>

--- a/Tutorials/learn-monogame-2d/src/27-Conclusion/DungeonSlime/DungeonSlime.csproj
+++ b/Tutorials/learn-monogame-2d/src/27-Conclusion/DungeonSlime/DungeonSlime.csproj
@@ -23,7 +23,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Gum.MonoGame" Version="2025.12.9.1" />
+    <PackageReference Include="Gum.MonoGame" Version="2026.5.2.1" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>


### PR DESCRIPTION
…b wrapping bug

fixes #114

## What is the bug

Previously if a user used the keyboard to navigate through the title screen UI, they could go to the options screen, tab up to the sliders, then continue tabbing up and the game would give focus to the now-hidden Start/Options buttons that were visible before going into the options.

The reason is because Gum was incorrectly handling tab navigation with enabled-but-hidden buttons.

## What is the fix

I was able to reproduce the bug in an automated test project, implemented a fix, then verified that the fix solved both the automated test and also the samples projects.

We had to wait for the April 2026 release (which came out this week) before I could create this PR.