### PR TITLE
Use WasKeyJustPressed for ExitOnEscape

### DIFF
--- a/Tutorials/learn-monogame-2d/src/11-Input-Management/MonoGameLibrary/Core.cs
+++ b/Tutorials/learn-monogame-2d/src/11-Input-Management/MonoGameLibrary/Core.cs
@@ -112,7 +112,7 @@ public class Core : Game
         // Update the input manager
         Input.Update(gameTime);
 
-        if (ExitOnEscape && Input.Keyboard.IsKeyDown(Keys.Escape))
+        if (ExitOnEscape && Input.Keyboard.WasKeyJustPressed(Keys.Escape))
         {
             Exit();
         }

--- a/Tutorials/learn-monogame-2d/src/12-Collision-Detection/MonoGameLibrary/Core.cs
+++ b/Tutorials/learn-monogame-2d/src/12-Collision-Detection/MonoGameLibrary/Core.cs
@@ -112,7 +112,7 @@ public class Core : Game
         // Update the input manager
         Input.Update(gameTime);
 
-        if (ExitOnEscape && Input.Keyboard.IsKeyDown(Keys.Escape))
+        if (ExitOnEscape && Input.Keyboard.WasKeyJustPressed(Keys.Escape))
         {
             Exit();
         }

--- a/Tutorials/learn-monogame-2d/src/13-Tilemap/MonoGameLibrary/Core.cs
+++ b/Tutorials/learn-monogame-2d/src/13-Tilemap/MonoGameLibrary/Core.cs
@@ -112,7 +112,7 @@ public class Core : Game
         // Update the input manager
         Input.Update(gameTime);
 
-        if (ExitOnEscape && Input.Keyboard.IsKeyDown(Keys.Escape))
+        if (ExitOnEscape && Input.Keyboard.WasKeyJustPressed(Keys.Escape))
         {
             Exit();
         }

--- a/Tutorials/learn-monogame-2d/src/14-SoundEffects-And-Music/MonoGameLibrary/Core.cs
+++ b/Tutorials/learn-monogame-2d/src/14-SoundEffects-And-Music/MonoGameLibrary/Core.cs
@@ -112,7 +112,7 @@ public class Core : Game
         // Update the input manager
         Input.Update(gameTime);
 
-        if (ExitOnEscape && Input.Keyboard.IsKeyDown(Keys.Escape))
+        if (ExitOnEscape && Input.Keyboard.WasKeyJustPressed(Keys.Escape))
         {
             Exit();
         }

--- a/Tutorials/learn-monogame-2d/src/15-Audio-Controller/MonoGameLibrary/Core.cs
+++ b/Tutorials/learn-monogame-2d/src/15-Audio-Controller/MonoGameLibrary/Core.cs
@@ -132,7 +132,7 @@ public class Core : Game
         // Update the audio controller.
         Audio.Update();
 
-        if (ExitOnEscape && Input.Keyboard.IsKeyDown(Keys.Escape))
+        if (ExitOnEscape && Input.Keyboard.WasKeyJustPressed(Keys.Escape))
         {
             Exit();
         }

--- a/Tutorials/learn-monogame-2d/src/16-Working-With-SpriteFonts/MonoGameLibrary/Core.cs
+++ b/Tutorials/learn-monogame-2d/src/16-Working-With-SpriteFonts/MonoGameLibrary/Core.cs
@@ -132,7 +132,7 @@ public class Core : Game
         // Update the audio controller.
         Audio.Update();
 
-        if (ExitOnEscape && Input.Keyboard.IsKeyDown(Keys.Escape))
+        if (ExitOnEscape && Input.Keyboard.WasKeyJustPressed(Keys.Escape))
         {
             Exit();
         }

--- a/Tutorials/learn-monogame-2d/src/17-Scenes/DungeonSlime/Scenes/GameScene.cs
+++ b/Tutorials/learn-monogame-2d/src/17-Scenes/DungeonSlime/Scenes/GameScene.cs
@@ -253,7 +253,7 @@ public class GameScene : Scene
         KeyboardInfo keyboard = Core.Input.Keyboard;
 
         // If the escape key is pressed, return to the title screen
-        if (Core.Input.Keyboard.WasKeyJustPressed(Keys.Escape))
+        if (keyboard.WasKeyJustPressed(Keys.Escape))
         {
             Core.ChangeScene(new TitleScene());
         }

--- a/Tutorials/learn-monogame-2d/src/17-Scenes/DungeonSlime/Scenes/GameScene.cs
+++ b/Tutorials/learn-monogame-2d/src/17-Scenes/DungeonSlime/Scenes/GameScene.cs
@@ -249,7 +249,7 @@ public class GameScene : Scene
 
     private void CheckKeyboardInput()
     {
-        // Get a reference to the keyboard inof
+        // Get a reference to the keyboard info
         KeyboardInfo keyboard = Core.Input.Keyboard;
 
         // If the escape key is pressed, return to the title screen


### PR DESCRIPTION
Use WasKeyJustPressed instead of IsKeyDown which causes issues in later chapters of the tutorial. Following the tutorial, going from 16-Working-With-Sprite-Fonts to 17-Scenes, we will reach a state that causes the title screen to be skipped on Escape press. A single Esc press exits the game completely instead of going to the title screen. 

There is a [demo branch](https://github.com/IvanJoskic/MonoGame.Samples/tree/bug_demo_is_key_down/Tutorials/learn-monogame-2d/src/17-Scenes) on my fork (the changes are in 17-Scenes).

Looking at the [source code](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.4/Tutorials/learn-monogame-2d/src/17-Scenes/MonoGameLibrary/Core.cs) for 17-Scenes there already is a silent fix for this. But it's unnoticed because the chapters before and the tutorial still use IsKeyDown.

Related PR on docs: https://github.com/MonoGame/docs.monogame.github.io/pull/268

Also snuck in a typo fix.
